### PR TITLE
Two fixes for the MongoDB servers

### DIFF
--- a/group_vars/mongodb/public.yml
+++ b/group_vars/mongodb/public.yml
@@ -3,6 +3,11 @@ mongodb_daemon_name: "mongodb"
 mongodb_net_bindip: "0.0.0.0"
 mongodb_security_authorization: "enabled"
 mongodb_storage_dbpath: "/var/lib/mongodb"
+# We do not enable the quota, but noticed that it gets enforced at least in some
+# contexts anyway.  Setting this to 36 results in a quota of 64 GB per database,
+# which ought to be enough for anybody.  (Currently, our by far biggest instance
+# is using 14 GB for the module store.)
+mongodb_storage_quota_maxfiles: 36
 mongodb_systemlog_path: "/var/lib/mongodb/log/{{ mongodb_daemon_name }}.log"
 mongodb_pymongo_from_pip: true
 

--- a/requirements.yml
+++ b/requirements.yml
@@ -57,4 +57,4 @@
 
 - name: greendayonfire.mongodb
   src: https://github.com/UnderGreen/ansible-role-mongodb
-  version: 084f09a78960f1f4b4b17b24606aca54acd63308
+  version: 2dec49074d5e5904ac655d425cfc0267a9613a26


### PR DESCRIPTION
This PR fixes two unrelated issues we found with the MongoDB servers:

1. The latest released version of the greendayonfire.mongodb role has broken systemd support, but fixes have been merged to master, so we use that now.
2. Increase the quota to some "high enough" value.  While the quota _should_ not be enforced, it sometimes seems to be enforced anyway, so let's use a reasonable value here.  The value measures the quota in "files".  MongoDB creates a succession of files to store the data, starting with a file size of 64MB and using twice as much for the next file, levelling out at 2GB.  Thus, the value of 36 I use corresponds to a quota of 64GB.

Reviewer: @itsjeyd 