### PR TITLE
Remove useles group variables.

### DIFF
--- a/group_vars/all/public.yml
+++ b/group_vars/all/public.yml
@@ -2,4 +2,6 @@ tarsnap_version: 1.0.37
 tarsnap_cache: /var/tarsnap/cache
 tarsnap_cron_hour: "*"
 
-FORWARD_MAIL_RELAY_MAIL_TO: 'ops@example.com'
+FORWARD_MAIL_RELAY_MAIL_TO: '{{ OPS_EMAIL }}'
+COMMON_SERVER_ETCKEEPER_COMMIT_EMAIL: '{{ OPS_EMAIL }}'
+security_autoupdate_mail_to: '{{ OPS_EMAIL }}'


### PR DESCRIPTION
These variables take precedence over variables set in the inventory group_vars, so we remove them here.