### PR TITLE
Remove erroneous variable override for postgres backup location

### DIFF
--- a/group_vars/postgres/public.yml
+++ b/group_vars/postgres/public.yml
@@ -1,6 +1,5 @@
 POSTGRES_SERVER_DOMAIN: "{{ inventory_hostname }}"
 
-POSTGRES_SERVER_BACKUP_DIR: "/var/lib/postgres/backup"
 TARSNAP_BACKUP_PRE_SCRIPT: "/usr/local/sbin/backup-pre.sh"
 TARSNAP_BACKUP_POST_SCRIPT: "/usr/local/sbin/backup-post.sh"
 TARSNAP_BACKUP_FOLDERS: "{{ POSTGRES_SERVER_BACKUP_DIR }}"


### PR DESCRIPTION
This removes an extra unnecessary template override which caused backups to be stored in the wrong directory, filling a disk on the postgres server.